### PR TITLE
Fixing invalid regionEndpoint and Key does not exists issue

### DIFF
--- a/IO/S3FileSystem.cs
+++ b/IO/S3FileSystem.cs
@@ -359,15 +359,10 @@ namespace Umbraco.StorageProviders.S3.IO
         {
             var s3config = new AmazonS3Config()
             {
+                ServiceURL = Config.ServiceUrl,
                 RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(Config.Region),
                 ForcePathStyle = Config.ForcePathStyle,
-                ServiceURL = Config.ServiceUrl
             };
-
-            if (string.IsNullOrEmpty(Config.ServiceUrl))
-            {
-                s3config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(Config.Region);
-            }
 
             BasicAWSCredentials creds = new BasicAWSCredentials(Config.AccessKey, Config.SecretKey);
 

--- a/IO/S3FileSystem.cs
+++ b/IO/S3FileSystem.cs
@@ -364,6 +364,11 @@ namespace Umbraco.StorageProviders.S3.IO
                 ServiceURL = Config.ServiceUrl
             };
 
+            if (string.IsNullOrEmpty(Config.ServiceUrl))
+            {
+                s3config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(Config.Region);
+            }
+
             BasicAWSCredentials creds = new BasicAWSCredentials(Config.AccessKey, Config.SecretKey);
 
             return new AmazonS3Client(creds, s3config);

--- a/Imaging/S3FileSystemImageProvider.cs
+++ b/Imaging/S3FileSystemImageProvider.cs
@@ -91,11 +91,15 @@ namespace Umbraco.StorageProviders.S3.Imaging
             var blob = _fileSystemProvider
                 .GetFileSystem(_name)
                 .GetS3Client();
-            
-            try {
-                var image = await blob.GetObjectAsync(s3config.BucketName, context.Request.Path).ConfigureAwait(false);
+
+            try
+            {
+                var path = context.Request.Path.Value!.TrimStart('/');
+                var image = await blob.GetObjectAsync(s3config.BucketName, path).ConfigureAwait(false);
                 return new S3StorageImageResolver(image);
-            } catch (AggregateException e) {
+            }
+            catch (AggregateException e)
+            {
                 if (e.InnerException is AmazonS3Exception)
                 {
                     AmazonS3Exception ex = (AmazonS3Exception)e.InnerException;

--- a/Imaging/S3FileSystemImageProvider.cs
+++ b/Imaging/S3FileSystemImageProvider.cs
@@ -94,7 +94,7 @@ namespace Umbraco.StorageProviders.S3.Imaging
 
             try
             {
-                var path = context.Request.Path.Value!.TrimStart('/');
+                var path = context.Request.Path.Value.TrimStart('/');
                 var image = await blob.GetObjectAsync(s3config.BucketName, path).ConfigureAwait(false);
                 return new S3StorageImageResolver(image);
             }

--- a/S3FileSystemMiddleware.cs
+++ b/S3FileSystemMiddleware.cs
@@ -73,8 +73,10 @@ namespace Umbraco.StorageProviders.S3
             //    x.ModifiedSinceDate = 
             //};
 
-            try {
-                properties = await client.GetObjectAsync(s3config.BucketName, context.Request.Path);
+            try
+            {
+                var path = context.Request.Path.Value.TrimStart("/");
+                properties = await client.GetObjectAsync(s3config.BucketName, path).ConfigureAwait(false);
             } catch (AggregateException e) {
                 if (e.InnerException is AmazonS3Exception)
                 {

--- a/S3FileSystemMiddleware.cs
+++ b/S3FileSystemMiddleware.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Extensions;
 using Umbraco.StorageProviders.S3.IO;
 
 namespace Umbraco.StorageProviders.S3


### PR DESCRIPTION
Resolves issue setting region when the config.ServiceUrl is null. Basically you cannot set the region property when the ServiceUrl is empty. Also, retrieving image fails when you pass Request.Path to GetObjectAsync as the path contains / at the from like /media/image.jpg but the image key is s3 is media/image.jpg
